### PR TITLE
Minor changes to Frida script and its usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Next, you will need to pull the file from the device
 The resulting offset from the dump can be used in the frida [script](https://github.com/Impact-I/reFlutter/blob/main/frida.js)
 
 ```
-frida -U -f <package> -l frida.js --no-pause
+frida -U -f <package> -l frida.js
 ```
 
 To get value for `_kDartIsolateSnapshotInstructions` you can use `readelf -Ws libapp.so` Where is the value you need in the `Value` field

--- a/frida.js
+++ b/frida.js
@@ -1,4 +1,4 @@
-//frida -U -f <package> -l frida.js --no-pause
+//frida -U -f <package> -l frida.js
 
 function hookFunc() {
 


### PR DESCRIPTION
Removed `--no-pause` which has been removed in recent versions of Frida as app is no longer paused by default now.